### PR TITLE
Fix for issue#2

### DIFF
--- a/src/Http/Controllers/LoginController.php
+++ b/src/Http/Controllers/LoginController.php
@@ -135,9 +135,7 @@ class LoginController extends Controller
                     ]
                 ]
             ],
-            'accountStores' => [
-                app('cache.store')->get('stormpath.accountStores')
-            ],
+            'accountStores' => app('cache.store')->get('stormpath.accountStores'),
 
         ];
         return response($data)->header('Content-Type', 'application/json');


### PR DESCRIPTION
Remove extraneous array wrapper from accountStores as `cache.store` already returns an array
